### PR TITLE
feature: Add vocab-configs import/export service ("migration vocabularies")

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -31,11 +31,13 @@ defmodule Acl.UserGroups.Config do
                         "http://mu.semte.ch/vocabularies/ext/VocabDownloadJob",
                         "http://mu.semte.ch/vocabularies/ext/MetadataExtractionJob",
                         "http://mu.semte.ch/vocabularies/ext/ContentUnificationJob",
+                        "http://mu.semte.ch/vocabularies/ext/VocabsExportJob",
+                        "http://mu.semte.ch/vocabularies/ext/VocabsImportJob",
                         "http://vocab.deri.ie/cogs#Job",
                         "http://redpencil.data.gift/vocabularies/tasks/Task",
                         "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#DataContainer",
                         "http://open-services.net/ns/core#Error",
-                        "http://mu.semte.ch/vocabularies/ext/alias",
+                        "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject",
                       ]
                     } } ] },
 

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -38,6 +38,72 @@ export default [
       // form of element is {subject,predicate,object}
       predicate: {
         type: "uri",
+        value: "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+      },
+      object: {
+        type: "uri",
+        value: "http://mu.semte.ch/vocabularies/ext/VocabsExportJob",
+      },
+    },
+    callback: {
+      url: "http://vocab-configs/delta",
+      method: "POST",
+    },
+    options: {
+      resourceFormat: "v0.0.1",
+      gracePeriod: 1000,
+      ignoreFromSelf: true,
+    },
+  },
+  {
+    match: {
+      // form of element is {subject,predicate,object}
+      predicate: {
+        type: "uri",
+        value: "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+      },
+      object: {
+        type: "uri",
+        value: "http://mu.semte.ch/vocabularies/ext/VocabsImportJob",
+      },
+    },
+    callback: {
+      url: "http://vocab-configs/delta",
+      method: "POST",
+    },
+    options: {
+      resourceFormat: "v0.0.1",
+      gracePeriod: 1000,
+      ignoreFromSelf: true,
+    },
+  },
+  {
+    match: {
+      // form of element is {subject,predicate,object}
+      predicate: {
+        type: "uri",
+        value: "http://www.w3.org/ns/adms#status",
+      },
+      object: {
+        type: "uri",
+        value: "http://redpencil.data.gift/id/concept/JobStatus/scheduled",
+      },
+    },
+    callback: {
+      url: "http://vocab-configs/delta",
+      method: "POST",
+    },
+    options: {
+      resourceFormat: "v0.0.1",
+      gracePeriod: 1000,
+      ignoreFromSelf: true,
+    },
+  },
+  {
+    match: {
+      // form of element is {subject,predicate,object}
+      predicate: {
+        type: "uri",
         value: "http://www.w3.org/ns/adms#status",
       },
       object: {

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -64,6 +64,22 @@ defmodule Dispatcher do
     forward conn, path, "http://resource/tasks/"
   end
 
+  get "/files/:id/download", @any do
+    Proxy.forward conn, [], "http://file/files/" <> id <> "/download"
+  end
+
+  post "/files/*path", @any do
+    Proxy.forward conn, path, "http://file/files/"
+  end
+
+  delete "/files/*path", %{ accept: [ :json ] } do
+    Proxy.forward conn, path, "http://file/files/"
+  end
+
+  get "/files/*path", @json do
+    Proxy.forward conn, path, "http://resource/files/"
+  end
+
   match "/data-containers/*path", @json do
     forward conn, path, "http://resource/data-containers/"
   end

--- a/config/job-controller/config.json
+++ b/config/job-controller/config.json
@@ -12,5 +12,23 @@
         "nextIndex": "1"
       }
     ]
+  },
+  "http://lblod.data.gift/id/jobs/concept/JobOperation/vocabs-export": {
+    "tasksConfiguration": [
+      {
+        "currentOperation": null,
+        "nextOperation": "http://mu.semte.ch/vocabularies/ext/VocabsExportJob",
+        "nextIndex": "0"
+      }
+    ]
+  },
+  "http://lblod.data.gift/id/jobs/concept/JobOperation/vocabs-import": {
+    "tasksConfiguration": [
+      {
+        "currentOperation": null,
+        "nextOperation": "http://mu.semte.ch/vocabularies/ext/VocabsImportJob",
+        "nextIndex": "0"
+      }
+    ]
   }
 }

--- a/config/job-controller/config.json
+++ b/config/job-controller/config.json
@@ -10,6 +10,11 @@
         "currentOperation": "http://mu.semte.ch/vocabularies/ext/VocabDownloadJob",
         "nextOperation": "http://mu.semte.ch/vocabularies/ext/MetadataExtractionJob",
         "nextIndex": "1"
+      },
+      {
+        "currentOperation": "http://mu.semte.ch/vocabularies/ext/MetadataExtractionJob",
+        "nextOperation": "http://mu.semte.ch/vocabularies/ext/ContentUnificationJob",
+        "nextIndex": "2"
       }
     ]
   },

--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -16,6 +16,6 @@
   :has-one `((file :via ,(s-prefix "nie:dataSource")
                    :inverse t
                    :as "download"))
-  :resource-base (s-url "http://data.example.com/files/")
+  :resource-base (s-url "http://example-resource.com/files/")
   :features `(include-uri)
   :on-path "files")

--- a/config/resources/shacl.json
+++ b/config/resources/shacl.json
@@ -44,7 +44,8 @@
         },
         "description": {
           "type": "string",
-          "predicate": "sh:description"
+          "predicate": "sh:description",
+          "_comment": "in shacl spec this is a non-structured string predicate. In our implementation however, this field contains the URI of the predicate to which we want to map this path (in string form)"
         },
         "minCount": {
           "type": "integer",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,14 @@ services:
       - ./config/migrations:/data/migrations
     restart: always
     logging: *default-logging
+  file:
+    image: semtech/mu-file-service:3.2.0
+    environment:
+      FILE_RESOURCE_BASE: "http://example-resource.com/files/"
+    volumes:
+      - ./data/files:/share
+    restart: always
+    logging: *default-logging  
   resource:
     image: semtech/mu-cl-resources:1.23.0
     links:
@@ -139,6 +147,17 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock"
     restart: always
     logging: *default-logging
+  vocab-configs:
+    build: ./services/vocab-configs
+    environment:
+      MU_APPLICATION_FILE_STORAGE_PATH: "vocab-configs/"
+      MODE: "development"
+      MU_SPARQL_ENDPOINT: "http://database:8890/sparql"
+      MU_SPARQL_DIRECT_UPDATEPOINT:  "http://triplestore:8890/sparql"
+      MU_AUTH_ENDPOINT: "http://database:8890/sparql"
+    volumes:
+      - ./data/files:/share
+      - ./services/vocab-configs/:/app
 networks:
   ldes-consumers:
     name: ldes-consumers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,6 +114,7 @@ services:
       - ./services/vocab-fetch/:/app
     # Run in dev mode to circument memory limitations
     environment:
+      MU_VIRTUOSO_ENDPOINT: "http://triplestore:8890/sparql"
       MODE: "development"
     restart: always
     logging: *default-logging

--- a/services/content-unification/dataset.py
+++ b/services/content-unification/dataset.py
@@ -11,15 +11,18 @@ PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX dct: <http://purl.org/dc/terms/>
 PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
-SELECT (?page AS ?download_link) ?format ?download_url ?data_dump ?creation_date ?dataset_graph
+SELECT DISTINCT ?format ?download_url ?data_dump ?creation_date ?dataset_graph
 WHERE {
     GRAPH $graph {
         $dataset
             a void:Dataset .
         OPTIONAL {
-            $dataset void:dataDump ?data_dump ;
-            foaf:page ?download_url ;
-            void:feature ?format .
+            $dataset
+                foaf:page ?download_url ;
+                void:feature ?format .
+        }
+        OPTIONAL {
+            $dataset void:dataDump ?data_dump .
             ?data_dump dct:created ?creation_date .
         }
         OPTIONAL {

--- a/services/content-unification/sparql_util.py
+++ b/services/content-unification/sparql_util.py
@@ -50,6 +50,17 @@ def sparql_construct_res_to_graph(res):
         g.add((s, p, o))
     return g
 
+def binding_results(json_result, binded_values):
+  bindings = []
+  for binding in json_result["results"]["bindings"]:
+      if isinstance(binded_values, tuple):
+        values = tuple(binding[key]["value"] for key in binded_values)
+      else:
+        values = binding[binded_values]["value"]  
+      bindings.append(values)
+  return bindings
+
+
 def copy_graph_to_temp(graph, temp_named_graph=None):
     query_string = Template("""
 INSERT {

--- a/services/content-unification/task.py
+++ b/services/content-unification/task.py
@@ -112,6 +112,34 @@ LIMIT 1
     )
     return query_string
 
+def find_actionable_task_of_type(types, graph):
+    query_template = Template("""
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX cogs: <http://vocab.deri.ie/cogs#>
+PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+SELECT (?task as ?uri) (?uuid as ?id) ?created ?used ?operation WHERE {
+    GRAPH $graph {
+        ?task a task:Task ;
+            dct:created ?created ;
+            adms:status <http://redpencil.data.gift/id/concept/JobStatus/scheduled> ;
+            task:operation ?operation ;
+            mu:uuid ?uuid .
+        OPTIONAL { ?task task:inputContainer/ext:content ?used }
+        VALUES ?operation {$task_types}
+    }
+} LIMIT 1
+""")
+    query_string = query_template.substitute(
+        graph=sparql_escape_uri(graph) if graph else "?g",
+        task_types = " ".join([sparql_escape_uri(uri) for uri in types])
+        )
+    return query_string
+
+
 def run_task(task_uri, graph, runner_func, sparql_query, sparql_update):
     # start_time = time.time()
 
@@ -126,7 +154,7 @@ def run_task(task_uri, graph, runner_func, sparql_query, sparql_update):
 
     sparql_update(update_task_status(task_uri, STATUS_BUSY, graph))
     try:
-        generated = runner_func(used)
+        generated = [result for result in runner_func(used) if result] # remove non-uri values
         if generated:
             logger.info(f"Running task <{task_uri}> with source <{used[0]}> generated <{generated[0]}>")
             sparql_update(attach_task_results_container(task_uri, generated, graph))

--- a/services/content-unification/task.py
+++ b/services/content-unification/task.py
@@ -1,17 +1,22 @@
-
 import os
 import datetime
 from string import Template
-from escape_helpers import sparql_escape_uri, sparql_escape_datetime, sparql_escape_string
+from escape_helpers import (
+    sparql_escape_uri,
+    sparql_escape_datetime,
+    sparql_escape_string,
+    sparql_escape,
+)
 from helpers import generate_uuid, logger
 import traceback
 
 MU_APPLICATION_GRAPH = os.environ.get("MU_APPLICATION_GRAPH")
 
-STATUS_BUSY = 'http://redpencil.data.gift/id/concept/JobStatus/busy'
-STATUS_SCHEDULED = 'http://redpencil.data.gift/id/concept/JobStatus/scheduled'
-STATUS_SUCCESS = 'http://redpencil.data.gift/id/concept/JobStatus/success'
-STATUS_FAILED = 'http://redpencil.data.gift/id/concept/JobStatus/failed'
+STATUS_BUSY = "http://redpencil.data.gift/id/concept/JobStatus/busy"
+STATUS_SCHEDULED = "http://redpencil.data.gift/id/concept/JobStatus/scheduled"
+STATUS_SUCCESS = "http://redpencil.data.gift/id/concept/JobStatus/success"
+STATUS_FAILED = "http://redpencil.data.gift/id/concept/JobStatus/failed"
+
 
 def attach_task_results_container(task, results, graph=MU_APPLICATION_GRAPH):
     CONTAINER_URI_PREFIX = 'http://redpencil.data.gift/id/container/'
@@ -44,11 +49,16 @@ WHERE {
         task=sparql_escape_uri(task),
         container_uuid=sparql_escape_string(container_uuid),
         container=sparql_escape_uri(container_uri),
-        results=", ".join([sparql_escape_uri(result) for result in results])
+        results=", ".join([sparql_escape_uri(result) for result in results]),
     )
     return container_query_string
 
+
 def update_task_status(task, status, graph=MU_APPLICATION_GRAPH):
+    update_tasks_status([task], status, graph)
+
+
+def update_tasks_status(tasks, status, graph=MU_APPLICATION_GRAPH):
     time = datetime.datetime.now()
 
     query_template = Template("""
@@ -58,28 +68,30 @@ PREFIX dct: <http://purl.org/dc/terms/>
 
 DELETE {
     GRAPH $graph {
-        $task adms:status ?old_status ;
+        ?task adms:status ?old_status ;
             dct:modified ?old_modified .
     }
 }
 INSERT {
     GRAPH $graph {
-        $task adms:status $new_status ;
+        ?task adms:status $new_status ;
             dct:modified $modified .
     }
 }
 WHERE {
   GRAPH $graph {
-      $task a task:Task ;
+      VALUES ?task {$tasks}
+      ?task a task:Task ;
             adms:status ?old_status .
-      OPTIONAL { $task dct:modified ?old_modified }
+      OPTIONAL { ?task dct:modified ?old_modified }
+      
   }
 }""")
     query_string = query_template.substitute(
         graph=sparql_escape_uri(graph) if graph else "?g",
-        task=sparql_escape_uri(task),
+        tasks=" ".join([sparql_escape_uri(task) for task in tasks]),
         new_status=sparql_escape_uri(status),
-        modified=sparql_escape_datetime(time)
+        modified=sparql_escape_datetime(time),
     )
     return query_string
 
@@ -112,6 +124,7 @@ LIMIT 1
     )
     return query_string
 
+
 def find_actionable_task_of_type(types, graph):
     query_template = Template("""
 PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -131,38 +144,111 @@ SELECT (?task as ?uri) (?uuid as ?id) ?created ?used ?operation WHERE {
         OPTIONAL { ?task task:inputContainer/ext:content ?used }
         VALUES ?operation {$task_types}
     }
-} LIMIT 1
+} 
+ORDER BY ASC(?created)
+LIMIT 1
 """)
     query_string = query_template.substitute(
         graph=sparql_escape_uri(graph) if graph else "?g",
-        task_types = " ".join([sparql_escape_uri(uri) for uri in types])
+        task_types=" ".join([sparql_escape_uri(uri) for uri in types]),
+    )
+    return query_string
+
+
+# return scheduled tasks that have the same operation and input (as array of uris)
+def find_same_scheduled_tasks(operation, inputs, graph):
+    query_template = Template("""
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX cogs: <http://vocab.deri.ie/cogs#>
+PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+SELECT (?task as ?uri) (?uuid as ?id) ?created WHERE {
+    GRAPH $graph {
+        ?task a task:Task ;
+        adms:status <http://redpencil.data.gift/id/concept/JobStatus/scheduled> ;
+        dct:created ?created ;
+        task:operation $operation ;
+        mu:uuid ?uuid .
+        $task_contents_triples 
+    }
+} 
+""")
+    task_contents = ""
+    if inputs:
+        task_contents = f"?task task:inputContainer/ext:content {','.join([sparql_escape_uri(i) for i in inputs])}."
+    else:
+        # todo if no inputs is given, this should return task with no input (add a FILTER?). Not needed at this point
+        raise Exception(
+            "No `inputs` given to `find_same_scheduled_tasks`. This is not implemented."
         )
+
+    query_string = query_template.substitute(
+        graph=sparql_escape_uri(graph) if graph else "?g",
+        operation=sparql_escape_uri(operation),
+        task_contents_triples=task_contents,
+    )
+    return query_string
+
+
+def get_input_contents_task(task_uri, graph):
+    query_template = Template("""
+PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+SELECT ?content WHERE {
+    GRAPH $graph {
+        $task_uri a task:Task ;
+                  task:inputContainer/ext:content ?content.
+    }
+}
+""")
+    query_string = query_template.substitute(
+        graph=sparql_escape_uri(graph) if graph else "?g",
+        task_uri=sparql_escape_uri(task_uri),
+    )
     return query_string
 
 
 def run_task(task_uri, graph, runner_func, sparql_query, sparql_update):
+    run_tasks([task_uri], graph, runner_func, sparql_query, sparql_update)
+
+
+# run the first task in task_uris, but set the status for all the given tasks
+# useful for tasks that are the same
+def run_tasks(task_uris, graph, runner_func, sparql_query, sparql_update):
+    task_uri = task_uris[0]
     # start_time = time.time()
 
     task_q = find_actionable_task(task_uri, graph)
     task_res = sparql_query(task_q)
     if task_res["results"]["bindings"]:
-        used = [binding["used"]["value"] for binding in task_res["results"]["bindings"] if "used" in binding]
+        used = [
+            binding["used"]["value"]
+            for binding in task_res["results"]["bindings"]
+            if "used" in binding
+        ]
     else:
         raise Exception(f"Didn't find actionable task for <{task_uri}>")
 
     logger.info(f"Started running task {task_uri}")
 
-    sparql_update(update_task_status(task_uri, STATUS_BUSY, graph))
+    sparql_update(update_tasks_status(task_uris, STATUS_BUSY, graph))
     try:
-        generated = [result for result in runner_func(used) if result] # remove non-uri values
+        generated = runner_func(used)
         if generated:
-            logger.info(f"Running task <{task_uri}> with source <{used[0]}> generated <{generated[0]}>")
-            sparql_update(attach_task_results_container(task_uri, generated, graph))
-        sparql_update(update_task_status(task_uri, STATUS_SUCCESS, graph))
+            logger.info(
+                f"Running task <{task_uri}> with source <{used[0]}> generated <{generated[0]}>"
+            )
+            for task in task_uris:
+              sparql_update(attach_task_results_container(task, generated, graph))
+        sparql_update(update_tasks_status(task_uris, STATUS_SUCCESS, graph))
         return generated
     except Exception as e:
         traceback.print_exc()
-        sparql_update(update_task_status(task_uri, STATUS_FAILED, graph))
+        sparql_update(update_tasks_status(task_uris, STATUS_FAILED, graph))
 
     # end_time = time.time()
     # logger.info(

--- a/services/content-unification/web.py
+++ b/services/content-unification/web.py
@@ -81,11 +81,19 @@ def run_vocab_unification(vocab_uri):
                 old_temp_named_graph = load_file_to_db(
                     dataset_versions[1]["data_dump"]["value"], VOCAB_GRAPH
                 )
+                # diffing now happens in triplestore. If we make sure everything gets stored
+                # as sorted ntriples files, this can be done on file basis. Would improve perf
+                # and avoid having to load everything to triplestore with python rdflib store
+                # as an intermediary (!)
                 diff_subjects = diff_graphs(old_temp_named_graph, new_temp_named_graph)
                 for diff_subjects_batch in batched(diff_subjects, 10):
                     query_sudo(delete_from_graph(diff_subjects_batch, VOCAB_GRAPH))
                 drop_graph(old_temp_named_graph)
         else:
+            # since we now also save ldes datasets to files, ldes datasets can also get
+            # cleanups that are made possible by diffing above.
+            # This should become a dead code path
+            # keep until we can assure that an ldes dataset always has a dump (still needs cron to trigger the dump download)
             copy_graph_to_temp(
                 dataset_versions[0]["dataset_graph"]["value"], temp_named_graph
             )

--- a/services/content-unification/web.py
+++ b/services/content-unification/web.py
@@ -1,5 +1,6 @@
 import os
 from string import Template
+import threading
 
 from rdflib import Graph, URIRef
 import requests
@@ -13,58 +14,107 @@ from helpers import query as sparql_query
 from helpers import update as sparql_update
 from sudo_query import query_sudo, auth_update_sudo as update_sudo
 
-from sparql_util import serialize_graph_to_sparql, sparql_construct_res_to_graph, load_file_to_db, drop_graph, \
-    diff_graphs, copy_graph_to_temp
+from sparql_util import (
+    binding_results,
+    serialize_graph_to_sparql,
+    sparql_construct_res_to_graph,
+    load_file_to_db,
+    drop_graph,
+    diff_graphs,
+    copy_graph_to_temp,
+)
 
-from task import run_task, find_actionable_task
+from task import find_actionable_task_of_type, run_task, find_actionable_task
 from vocabulary import get_vocabulary
 from dataset import get_dataset
 
-from unification import unify_from_node_shape, get_property_paths, get_ununified_batch, delete_from_graph
-from remove_vocab import remove_files, select_vocab_concepts_batch, remove_vocab_data_dumps, remove_vocab_source_datasets, remove_vocab_meta, remove_vocab_vocab_fetch_jobs, remove_vocab_vocab_unification_jobs, remove_vocab_partitions, remove_vocab_mapping_shape
+from unification import (
+    unify_from_node_shape,
+    get_property_paths,
+    get_ununified_batch,
+    delete_from_graph,
+)
+from remove_vocab import (
+    remove_files,
+    select_vocab_concepts_batch,
+    remove_vocab_data_dumps,
+    remove_vocab_source_datasets,
+    remove_vocab_meta,
+    remove_vocab_vocab_fetch_jobs,
+    remove_vocab_vocab_unification_jobs,
+    remove_vocab_partitions,
+    remove_vocab_mapping_shape,
+)
 
 # Maybe make these configurable
-FILE_RESOURCE_BASE = 'http://example-resource.com/'
+FILE_RESOURCE_BASE = "http://example-resource.com/"
 TASKS_GRAPH = "http://mu.semte.ch/graphs/public"
-TEMP_GRAPH_BASE = 'http://example-resource.com/graph/'
+TEMP_GRAPH_BASE = "http://example-resource.com/graph/"
 VOCAB_GRAPH = "http://mu.semte.ch/graphs/public"
 UNIFICATION_TARGET_GRAPH = "http://mu.semte.ch/graphs/public"
 MU_APPLICATION_GRAPH = os.environ.get("MU_APPLICATION_GRAPH")
-TEMP_GRAPH_BASE = 'http://example-resource.com/graph/'
+TEMP_GRAPH_BASE = "http://example-resource.com/graph/"
 
 CONT_UN_OPERATION = "http://mu.semte.ch/vocabularies/ext/ContentUnificationJob"
 
+
 def run_vocab_unification(vocab_uri):
-    vocab_sources = query_sudo(get_vocabulary(vocab_uri, VOCAB_GRAPH))['results']['bindings']
+    vocab_sources = query_sudo(get_vocabulary(vocab_uri, VOCAB_GRAPH))["results"][
+        "bindings"
+    ]
+
+    if not vocab_sources:
+        logger.debug(
+            f"vocab {vocab_uri} does not have a mapping. Unification cancelled."
+        )
+        return
+
     temp_named_graph = TEMP_GRAPH_BASE + generate_uuid()
     for vocab_source in vocab_sources:
-        dataset_versions = query_sudo(get_dataset(vocab_source['sourceDataset']['value'], VOCAB_GRAPH))['results']['bindings']
+        dataset_versions = query_sudo(
+            get_dataset(vocab_source["sourceDataset"]["value"], VOCAB_GRAPH)
+        )["results"]["bindings"]
         print(dataset_versions)
         # TODO: LDES check
-        if 'data_dump' in dataset_versions[0].keys():
-            new_temp_named_graph = load_file_to_db(dataset_versions[0]['data_dump']['value'], VOCAB_GRAPH, temp_named_graph)
-            if len(dataset_versions) > 1: # previous dumps exist
-                old_temp_named_graph = load_file_to_db(dataset_versions[1]['data_dump']['value'], VOCAB_GRAPH)
+        if "data_dump" in dataset_versions[0].keys():
+            new_temp_named_graph = load_file_to_db(
+                dataset_versions[0]["data_dump"]["value"], VOCAB_GRAPH, temp_named_graph
+            )
+            if len(dataset_versions) > 1:  # previous dumps exist
+                old_temp_named_graph = load_file_to_db(
+                    dataset_versions[1]["data_dump"]["value"], VOCAB_GRAPH
+                )
                 diff_subjects = diff_graphs(old_temp_named_graph, new_temp_named_graph)
                 for diff_subjects_batch in batched(diff_subjects, 10):
                     query_sudo(delete_from_graph(diff_subjects_batch, VOCAB_GRAPH))
                 drop_graph(old_temp_named_graph)
         else:
-            copy_graph_to_temp(dataset_versions[0]['dataset_graph']['value'], temp_named_graph)
-    prop_paths_qs = get_property_paths(vocab_sources[0]['mappingShape']['value'], VOCAB_GRAPH)
+            copy_graph_to_temp(
+                dataset_versions[0]["dataset_graph"]["value"], temp_named_graph
+            )
+    prop_paths_qs = get_property_paths(
+        vocab_sources[0]["mappingShape"]["value"], VOCAB_GRAPH
+    )
     prop_paths_res = query_sudo(prop_paths_qs)
 
-    for path_props in prop_paths_res['results']['bindings']:
+    for path_props in prop_paths_res["results"]["bindings"]:
         while True:
-            get_batch_qs = get_ununified_batch(path_props['destClass']['value'],
-                                               path_props['destPath']['value'],
-                                               [vocab_source['sourceDataset']['value'] for vocab_source in vocab_sources],
-                                               path_props['sourceClass']['value'],
-                                               path_props['sourcePathString']['value'], # !
-                                               temp_named_graph, VOCAB_GRAPH, 10)
+            get_batch_qs = get_ununified_batch(
+                path_props["destClass"]["value"],
+                path_props["destPath"]["value"],
+                [
+                    vocab_source["sourceDataset"]["value"]
+                    for vocab_source in vocab_sources
+                ],
+                path_props["sourceClass"]["value"],
+                path_props["sourcePathString"]["value"],  # !
+                temp_named_graph,
+                VOCAB_GRAPH,
+                10,
+            )
             # We might want to dump intermediary unified content to file before committing to store
             batch_res = query_sudo(get_batch_qs)
-            if not batch_res['results']['bindings']:
+            if not batch_res["results"]["bindings"]:
                 logger.info("Finished unification")
                 break
             else:
@@ -74,8 +124,10 @@ def run_vocab_unification(vocab_uri):
                 update_sudo(query_string)
 
     drop_graph(temp_named_graph)
+    return vocab_uri
 
-@app.route('/delete-vocabulary/<vocab_uuid>', methods=('DELETE',))
+
+@app.route("/delete-vocabulary/<vocab_uuid>", methods=("DELETE",))
 def delete_vocabulary(vocab_uuid: str):
     remove_files(vocab_uuid, VOCAB_GRAPH)
     update_sudo(remove_vocab_data_dumps(vocab_uuid, VOCAB_GRAPH))
@@ -83,7 +135,7 @@ def delete_vocabulary(vocab_uuid: str):
     # concepts may return too many results in mu-auth internal construct. Batch it here.
     while True:
         batch = query_sudo(select_vocab_concepts_batch(vocab_uuid, VOCAB_GRAPH))
-        bindings = batch['results']['bindings']
+        bindings = batch["results"]["bindings"]
         if bindings:
             g = sparql_construct_res_to_graph(batch)
             for query_string in serialize_graph_to_sparql(g, VOCAB_GRAPH, "DELETE"):
@@ -97,37 +149,64 @@ def delete_vocabulary(vocab_uuid: str):
     update_sudo(remove_vocab_source_datasets(vocab_uuid, VOCAB_GRAPH))
     update_sudo(remove_vocab_mapping_shape(vocab_uuid, VOCAB_GRAPH))
     update_sudo(remove_vocab_meta(vocab_uuid, VOCAB_GRAPH))
-    return '', 200
+    return "", 200
 
 
-@app.route('/delta', methods=['POST'])
-def process_delta():
-    inserts = request.json[0]['inserts']
+running_tasks_lock = threading.Lock()
+
+
+def run_tasks():
+    # run this function only once at a time to avoid overloading the service
+    acquired = running_tasks_lock.acquire(blocking=False)
+
+    if not acquired:
+        logger.debug("Already running `run_tasks`")
+        return
+
     try:
-        task_triple = next(filter(
-            lambda x: x['predicate']['value'] == 'http://www.w3.org/ns/adms#status' and x['object']['value'] == 'http://redpencil.data.gift/id/concept/JobStatus/scheduled',
-            inserts
-        ))
-    except StopIteration:
+        while True:
+            task_q = find_actionable_task_of_type([CONT_UN_OPERATION], TASKS_GRAPH)
+            task_res = query_sudo(task_q)
+            if task_res["results"]["bindings"]:
+                (task_uri, task_operation) = binding_results(
+                    task_res, ("uri", "operation")
+                )[0]
+            else:
+                logger.debug("No more tasks found")
+                return
+            try:
+                if task_operation == CONT_UN_OPERATION:
+                    logger.debug(f"Running task {task_uri}, operation {task_operation}")
+                    run_task(
+                        task_uri,
+                        TASKS_GRAPH,
+                        lambda sources: [run_vocab_unification(sources[0])],
+                        query_sudo,
+                        update_sudo,
+                    )
+
+            finally:
+                logger.warn(
+                    f"Problem while running task {task_uri}, operation {task_operation}"
+                )
+    finally:
+        running_tasks_lock.release()
+
+
+@app.route("/delta", methods=["POST"])
+def process_delta():
+    inserts = request.json[0]["inserts"]
+    task_triples = [
+        t
+        for t in inserts
+        if t["predicate"]["value"] == "http://www.w3.org/ns/adms#status"
+        and t["object"]["value"]
+        == "http://redpencil.data.gift/id/concept/JobStatus/scheduled"
+    ]
+    if not task_triples:
         return "Can't do anything with this delta. Skipping.", 500
-    task_uri = task_triple['subject']['value']
 
-    task_q = find_actionable_task(task_uri, TASKS_GRAPH)
-    task_res = query_sudo(task_q)
-    if task_res["results"]["bindings"]:
-        task_operation = [binding["operation"]['value'] for binding in task_res["results"]["bindings"] if "operation" in binding][0]
-    else:
-        return "Don't know how to handle task without operation type", 500
+    thread = threading.Thread(target=run_tasks)
+    thread.start()
 
-    if task_operation == CONT_UN_OPERATION:
-        logger.debug(f"Running task {task_uri}, operation {task_operation}")
-        run_task(
-            task_uri,
-            TASKS_GRAPH,
-            lambda sources: [run_vocab_unification(sources[0])],
-            query_sudo,
-            update_sudo
-        )
-        return '', 200
-    else:
-        return "Don't know how to handle task with operation type " + task_operation, 500
+    return "", 200

--- a/services/content-unification/web.py
+++ b/services/content-unification/web.py
@@ -64,10 +64,7 @@ def run_vocab_unification(vocab_uri):
     ]
 
     if not vocab_sources:
-        logger.debug(
-            f"vocab {vocab_uri} does not have a mapping. Unification cancelled."
-        )
-        return
+        raise Exception(f"Vocab {vocab_uri} does not have a mapping. Unification cancelled.")
 
     temp_named_graph = TEMP_GRAPH_BASE + generate_uuid()
     for vocab_source in vocab_sources:

--- a/services/vocab-configs/Dockerfile
+++ b/services/vocab-configs/Dockerfile
@@ -1,0 +1,3 @@
+FROM semtech/mu-python-template:2.0.0-beta.1
+LABEL maintainer=""
+ENV LOG_LEVEL="DEBUG"

--- a/services/vocab-configs/file.py
+++ b/services/vocab-configs/file.py
@@ -1,0 +1,98 @@
+import os
+from string import Template
+from escape_helpers import sparql_escape_uri, sparql_escape_string, sparql_escape_int, sparql_escape_datetime
+
+MU_APPLICATION_GRAPH = os.environ.get("MU_APPLICATION_GRAPH")
+RELATIVE_STORAGE_PATH = os.environ.get("MU_APPLICATION_FILE_STORAGE_PATH", "").rstrip("/")
+STORAGE_PATH = f"/share/{RELATIVE_STORAGE_PATH}"
+
+############################################################
+# TODO: keep this generic and extract into packaged module later
+############################################################
+
+def construct_insert_file_query(file, physical_file, graph=MU_APPLICATION_GRAPH):
+    """
+    Construct a SPARQL query for inserting a file.
+    :param file: dict containing properties for file
+    :param share_uri: 
+    :returns: string containing SPARQL query
+    """
+    query_template = Template("""
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX dbpedia: <http://dbpedia.org/ontology/>
+
+INSERT DATA {
+    GRAPH $graph {
+        $uri a nfo:FileDataObject ;
+            mu:uuid $uuid ;
+            nfo:fileName $name ;
+            dct:format $mimetype ;
+            dct:created $created ;
+            nfo:fileSize $size ;
+            dbpedia:fileExtension $extension .
+        $physical_uri a nfo:FileDataObject ;
+            mu:uuid $physical_uuid ;
+            nfo:fileName $physical_name ;
+            dct:format $mimetype ;
+            dct:created $created ;
+            nfo:fileSize $size ;
+            dbpedia:fileExtension $extension ;
+            nie:dataSource $uri .
+    }
+}
+""")
+    return query_template.substitute(
+        graph=sparql_escape_uri(graph),
+        uri=sparql_escape_uri(file["uri"]),
+        uuid=sparql_escape_string(file["uuid"]),
+        name=sparql_escape_string(file["name"]),
+        mimetype=sparql_escape_string(file["mimetype"]),
+        created=sparql_escape_datetime(file["created"]),
+        size=sparql_escape_int(file["size"]),
+        extension=sparql_escape_string(file["extension"]),
+        physical_uri=sparql_escape_uri(physical_file["uri"]),
+        physical_uuid=sparql_escape_string(physical_file["uuid"]),
+        physical_name=sparql_escape_string(physical_file["name"]))
+
+def construct_get_file_query(file_uri, graph=MU_APPLICATION_GRAPH):
+    """
+    Construct a SPARQL query for querying a file.
+    :param file_uri: string containing file uri
+    :returns: string containing SPARQL query
+    """
+    query_template = Template("""
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+PREFIX dbpedia: <http://dbpedia.org/ontology/>
+SELECT (?file_uri AS ?uri) ?uuid ?name ?size ?extension ?physicalFile
+WHERE {
+    GRAPH $graph {
+        $file_uri a nfo:FileDataObject ;
+            mu:uuid ?uuid ;
+            nfo:fileName ?name ;
+            nfo:fileSize ?size ;
+            dbpedia:fileExtension ?extension ;
+            ^nie:dataSource ?physicalFile .
+        BIND($file_uri AS ?file_uri)
+        ?physicalFile a nfo:FileDataObject .
+    }
+}
+""")
+    return query_template.substitute(
+        graph=sparql_escape_uri(graph),
+        file_uri=sparql_escape_uri(file_uri))
+
+# Ported from https://github.com/mu-semtech/file-service/blob/dd42c51a7344e4f7a3f7fba2e6d40de5d7dd1972/web.rb#L228
+def shared_uri_to_path(uri):
+    return uri.replace('share://', '/share/')
+
+# Ported from https://github.com/mu-semtech/file-service/blob/dd42c51a7344e4f7a3f7fba2e6d40de5d7dd1972/web.rb#L232
+def file_to_shared_uri(file_name):
+    if RELATIVE_STORAGE_PATH:
+        return f"share://{RELATIVE_STORAGE_PATH}/{file_name}"
+    else:
+        return f"share://{file_name}"

--- a/services/vocab-configs/requirements.txt
+++ b/services/vocab-configs/requirements.txt
@@ -1,0 +1,3 @@
+rdflib == 6.2.0
+requests ~= 2.28.1
+more-itertools == 9.0.0

--- a/services/vocab-configs/sparql_util.py
+++ b/services/vocab-configs/sparql_util.py
@@ -1,0 +1,114 @@
+from escape_helpers import sparql_escape_uri
+from helpers import logger, generate_uuid
+
+from sudo_query import query_sudo, direct_update_triplestore as update_virtuoso
+from file import construct_get_file_query, shared_uri_to_path
+
+import os
+from string import Template
+from more_itertools import batched
+from rdflib.graph import Graph
+from rdflib.term import URIRef, Literal
+
+TEMP_GRAPH_BASE = 'http://example-resource.com/graph/'
+MU_APPLICATION_GRAPH = os.environ.get("MU_APPLICATION_GRAPH")
+
+BATCH_SIZE = 100
+
+def binding_results(json_result, binded_values):
+  bindings = []
+  for binding in json_result["results"]["bindings"]:
+      if isinstance(binded_values, tuple):
+        values = tuple(binding[key]["value"] for key in binded_values)
+      else:
+        values = binding[binded_values]["value"]  
+      bindings.append(values)
+  return bindings
+
+# adapted from https://github.com/RDFLib/rdflib/issues/1704
+def serialize_graph_to_sparql(g, graph_name: str, operation="INSERT"):
+    # Note that the Graph triples method yields triples in random order
+    # Triples aren't grouped by subject. Current mu-search delta handling
+    # isn't affected by this.
+    for triples_batch in batched(g.triples((None, None, None)), BATCH_SIZE):
+        # updatequery = "\n".join([f"PREFIX {prefix}: {ns.n3()}" for prefix, ns in g.namespaces()])
+        # Dropping prefixes boosts performance. Since the '.n3()'-method produces ntriples compliant triples,
+        # dropping the prefixes yields an ntriples only query, which is significantly faster
+        updatequery = f"\n{operation} DATA {{\n\tGRAPH {sparql_escape_uri(graph_name)} {{\n"
+        updatequery += " .\n".join([f"\t\t{s.n3()} {p.n3()} {o.n3()}" for (s, p, o) in triples_batch])
+        updatequery += f" . \n\t }}\n}}\n"
+        yield updatequery
+
+def json_to_term(json_term):
+    if json_term['type'] == 'uri':
+        return URIRef(json_term['value'])
+    else:
+        if 'xml:lang' in json_term:  # SELECT
+            lang = json_term['xml:lang']
+        elif 'lang' in json_term:  # CONSTRUCT
+            lang = json_term['lang']
+        else:
+            lang = None
+        return Literal(json_term['value'], lang=lang)
+
+def sparql_construct_res_to_graph(res):
+    """ Turn results of a sparql construct query into an rdflib graph """
+    g = Graph()
+    for binding in res['results']['bindings']:
+        s = URIRef(binding['s']['value'])
+        p = URIRef(binding['p']['value'])
+        o = json_to_term(binding['o'])
+        g.add((s, p, o))
+    return g
+
+def copy_graph_to_temp(graph, temp_named_graph=None):
+    query_string = Template("""
+INSERT {
+    GRAPH $new_graph {?s ?p ?o .}
+}
+WHERE {
+    GRAPH $old_graph {?s ?p ?o .}
+}
+    """).substitute(
+        old_graph=sparql_escape_uri(graph),
+        new_graph=sparql_escape_uri(temp_named_graph),
+    )
+    update_virtuoso(query_string)
+    return temp_named_graph
+
+def upload_file_to_graph(file, graph):
+    g = Graph()
+    g.parse(file)
+    for query_string in serialize_graph_to_sparql(g, graph):
+        update_virtuoso(query_string)
+
+def load_file_to_db(uri: str, metadata_graph: str = MU_APPLICATION_GRAPH, temp_named_graph=None):
+    if not temp_named_graph:
+        temp_named_graph = TEMP_GRAPH_BASE + generate_uuid()
+    query_string = construct_get_file_query(uri, metadata_graph)
+    file_result = query_sudo(query_string)['results']['bindings'][0]
+    upload_file_to_graph(shared_uri_to_path(file_result['physicalFile']['value']), temp_named_graph)
+    return temp_named_graph
+
+def drop_graph(graph):
+    update_virtuoso("DROP SILENT GRAPH {}".format(sparql_escape_uri(graph)))
+
+def diff_graphs(graph_old, graph_new):
+    query_res = query_sudo(Template("""
+SELECT DISTINCT ?s
+WHERE {
+    GRAPH $new_graph {
+        ?s ?p ?o .
+    }
+    FILTER NOT EXISTS {
+        GRAPH $old_graph {
+            ?s ?p ?o .
+        }
+    }
+}
+""").substitute(
+    old_graph=sparql_escape_uri(graph_old),
+    new_graph=sparql_escape_uri(graph_new),
+))
+    s = [b['s']['value'] for b in query_res['results']['bindings']]
+    return s

--- a/services/vocab-configs/sudo_query.py
+++ b/services/vocab-configs/sudo_query.py
@@ -1,0 +1,69 @@
+import datetime
+import os
+import time
+
+from SPARQLWrapper import SPARQLWrapper, JSON
+from helpers import logger
+
+sparqlQuery = SPARQLWrapper(os.environ.get("MU_SPARQL_ENDPOINT"))
+sparqlQuery.addCustomHttpHeader("mu-auth-sudo", "true")
+sparqlUpdate = SPARQLWrapper(os.environ.get("MU_SPARQL_UPDATEPOINT"), returnFormat=JSON)
+sparqlUpdate.method = "POST"
+sparqlUpdate.addCustomHttpHeader("mu-auth-sudo", "true")
+
+authSparqlUpdate = SPARQLWrapper(os.environ.get("MU_AUTH_ENDPOINT"), returnFormat=JSON)
+authSparqlUpdate.method = "POST"
+authSparqlUpdate.addCustomHttpHeader("mu-auth-sudo", "true")
+
+sparqlQueryDirectUpdate = SPARQLWrapper(os.environ.get("MU_SPARQL_DIRECT_UPDATEPOINT"), returnFormat= JSON)
+sparqlQueryDirectUpdate.method = "POST"
+
+def query_sudo(the_query):
+    """Execute the given SPARQL query (select/ask/construct)on the triple store and returns
+    the results in the given returnFormat (JSON by default)."""
+    logger.debug("execute query: \n" + the_query)
+    sparqlQuery.setQuery(the_query)
+    return sparqlQuery.query().convert()
+
+def direct_update_triplestore(the_query, attempt=0, max_retries=5):
+    execute_update_query(sparqlQueryDirectUpdate, the_query, attempt, max_retries)
+
+def update_sudo(the_query, attempt=0, max_retries=5):
+    """Execute the given update SPARQL query on the triple store,
+    if the given query is no update query, nothing happens."""
+    execute_update_query(sparqlUpdate, the_query, attempt, max_retries)
+
+def execute_update_query(querier, the_query, attempt=0, max_retries=5):
+    querier.setQuery(the_query)
+    if querier.isSparqlUpdateRequest():
+        try:
+            start = time.time()
+            logger.debug(f"started query at {datetime.datetime.now()}")
+            logger.debug("execute query: \n" + the_query)
+
+            querier.query()
+
+            logger.debug(f"query took {time.time() - start} seconds")
+        except Exception as e:
+            logger.warn("Executing query failed unexpectedly. Stacktrace:", e)
+            if attempt <= max_retries:
+                wait_time = 0.6 * attempt + 30
+                logger.warn(f"Retrying after {wait_time} seconds [{attempt}/{max_retries}]")
+                time.sleep(wait_time)
+
+                execute_update_query(querier, the_query, attempt + 1, max_retries)
+            else:
+                logger.warn("Max attempts reached for query. Skipping.")
+                
+def auth_update_sudo(the_query):
+    """Execute the given update SPARQL query on the triple store,
+    if the given query is no update query, nothing happens."""
+    authSparqlUpdate.setQuery(the_query)
+    if authSparqlUpdate.isSparqlUpdateRequest():
+        start = time.time()
+        logger.debug(f"started query at {datetime.datetime.now()}")
+        logger.debug("execute query: \n" + the_query)
+
+        authSparqlUpdate.query()
+
+        logger.debug(f"query took {time.time() - start} seconds")

--- a/services/vocab-configs/task.py
+++ b/services/vocab-configs/task.py
@@ -1,0 +1,214 @@
+import os
+import datetime
+from string import Template
+from escape_helpers import (
+    sparql_escape_uri,
+    sparql_escape_datetime,
+    sparql_escape_string,
+)
+from helpers import generate_uuid, logger
+import traceback
+
+MU_APPLICATION_GRAPH = os.environ.get("MU_APPLICATION_GRAPH")
+
+STATUS_BUSY = "http://redpencil.data.gift/id/concept/JobStatus/busy"
+STATUS_SCHEDULED = "http://redpencil.data.gift/id/concept/JobStatus/scheduled"
+STATUS_SUCCESS = "http://redpencil.data.gift/id/concept/JobStatus/success"
+STATUS_FAILED = "http://redpencil.data.gift/id/concept/JobStatus/failed"
+
+CONTAINER_URI_PREFIX = "http://redpencil.data.gift/id/container/"
+JOB_URI_PREFIX = "http://redpencil.data.gift/id/job/"
+TASK_URI_PREFIX = "http://redpencil.data.gift/id/task/"
+
+
+def attach_task_results_container(task, results, graph=MU_APPLICATION_GRAPH):
+    container_uuid = generate_uuid()
+    container_uri = CONTAINER_URI_PREFIX + container_uuid
+
+    container_query_template = Template("""
+PREFIX cogs: <http://vocab.deri.ie/cogs#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
+PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+INSERT {
+    GRAPH $graph {
+        $task task:resultsContainer $container .
+        $container a nfo:DataContainer ;
+            mu:uuid $container_uuid ;
+            $results_query_part
+            .
+    }
+}
+WHERE {
+    GRAPH $graph {
+        $task a task:Task .
+    }
+}""")
+    container_query_string = container_query_template.substitute(
+        graph=sparql_escape_uri(graph) if graph else "?g",
+        task=sparql_escape_uri(task),
+        container_uuid=sparql_escape_string(container_uuid),
+        container=sparql_escape_uri(container_uri),
+        results_query_part=";".join(
+            [f"ext:content {sparql_escape_uri(result)} " for result in results]
+        ),
+    )
+    return container_query_string
+
+
+def update_task_status(task, status, graph=MU_APPLICATION_GRAPH):
+    time = datetime.datetime.now()
+
+    query_template = Template("""
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
+PREFIX dct: <http://purl.org/dc/terms/>
+
+DELETE {
+    GRAPH $graph {
+        $task adms:status ?old_status ;
+            dct:modified ?old_modified .
+    }
+}
+INSERT {
+    GRAPH $graph {
+        $task adms:status $new_status ;
+            dct:modified $modified .
+    }
+}
+WHERE {
+  GRAPH $graph {
+      $task a task:Task ;
+            adms:status ?old_status .
+      OPTIONAL { $task dct:modified ?old_modified }
+  }
+}""")
+    query_string = query_template.substitute(
+        graph=sparql_escape_uri(graph) if graph else "?g",
+        task=sparql_escape_uri(task),
+        new_status=sparql_escape_uri(status),
+        modified=sparql_escape_datetime(time),
+    )
+    return query_string
+
+
+def find_actionable_task(task_uri, graph=MU_APPLICATION_GRAPH):
+    query_template = Template("""
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX cogs: <http://vocab.deri.ie/cogs#>
+PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+SELECT (?uuid as ?id) ?created ?used ?operation WHERE {
+    GRAPH $graph {
+        $task_uri a task:Task ;
+            dct:created ?created ;
+            adms:status <http://redpencil.data.gift/id/concept/JobStatus/scheduled> ;
+            task:operation ?operation ;
+            mu:uuid ?uuid .
+        OPTIONAL { $task_uri task:inputContainer/ext:content ?used }
+    }
+}
+""")
+    query_string = query_template.substitute(
+        graph=sparql_escape_uri(graph) if graph else "?g",
+        task_uri=sparql_escape_uri(task_uri),
+    )
+    return query_string
+
+
+def start_download_task(dataset_uri, graph=MU_APPLICATION_GRAPH):
+    query_template = Template("""
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX cogs: <http://vocab.deri.ie/cogs#>
+PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    INSERT DATA {
+      GRAPH $graph {
+        $container_uri a nfo:DataContainer;
+          mu:uuid $container_uuid;
+          ext:content $dataset_uri .
+        $job_uri a cogs:Job ;
+          mu:uuid $job_uuid;
+          dct:created $created;
+          dct:modified $created;
+          dct:creator "empty";
+          task:operation <http://lblod.data.gift/id/jobs/concept/JobOperation/vocab-download> ;
+          adms:status <http://redpencil.data.gift/id/concept/JobStatus/scheduled> .
+        $task_uri a task:Task ;
+            mu:uuid $task_uuid ;
+            dct:created $created ;
+            dct:modified $created ;
+            task:index "0";
+            dct:isPartOf $job_uri;
+            task:inputContainer $container_uri;
+            task:operation <http://mu.semte.ch/vocabularies/ext/VocabDownloadJob> ;
+            adms:status <http://redpencil.data.gift/id/concept/JobStatus/scheduled> .
+      }
+    }
+  """)
+    container_uuid = generate_uuid()
+    container_uri = CONTAINER_URI_PREFIX + container_uuid
+    job_uuid = generate_uuid()
+    job_uri = JOB_URI_PREFIX + job_uuid
+    task_uuid = generate_uuid()
+    task_uri = TASK_URI_PREFIX + task_uuid
+    created = datetime.datetime.now()
+    query = query_template.substitute(
+        graph=sparql_escape_uri(graph),
+        container_uri=sparql_escape_uri(container_uri),
+        job_uri=sparql_escape_uri(job_uri),
+        task_uri=sparql_escape_uri(task_uri),
+        container_uuid=sparql_escape_string(container_uuid),
+        job_uuid=sparql_escape_string(job_uuid),
+        task_uuid=sparql_escape_string(task_uuid),
+        created=sparql_escape_datetime(created),
+        dataset_uri=sparql_escape_uri(dataset_uri)
+    )
+    
+    return query
+
+
+def run_task(task_uri, graph, runner_func, sparql_query, sparql_update):
+    # start_time = time.time()
+
+    task_q = find_actionable_task(task_uri, graph)
+    task_res = sparql_query(task_q)
+    if task_res["results"]["bindings"]:
+        used = [
+            binding["used"]["value"]
+            for binding in task_res["results"]["bindings"]
+            if "used" in binding
+        ]
+    else:
+        raise Exception(f"Didn't find actionable task for <{task_uri}>")
+
+    logger.info(f"Started running task {task_uri}")
+
+    sparql_update(update_task_status(task_uri, STATUS_BUSY, graph))
+    try:
+        generated = runner_func(used)
+        if generated:
+            logger.info(
+                f"Running task <{task_uri}> with source {used} generated {generated}"
+            )
+            sparql_update(attach_task_results_container(task_uri, generated, graph))
+        sparql_update(update_task_status(task_uri, STATUS_SUCCESS, graph))
+        return generated
+    except Exception as e:
+        traceback.print_exc()
+        sparql_update(update_task_status(task_uri, STATUS_FAILED, graph))
+
+    # end_time = time.time()
+    # logger.info(
+    # f"Finished running job at {start_time}, took {end_time - start_time} seconds"
+    # )

--- a/services/vocab-configs/vocabularies.py
+++ b/services/vocab-configs/vocabularies.py
@@ -1,0 +1,339 @@
+import os
+from string import Template
+from escape_helpers import (
+    sparql_escape_uri,
+    sparql_escape_datetime,
+    sparql_escape_string,
+)
+from helpers import generate_uuid, logger
+
+DATA_GRAPH = "http://mu.semte.ch/graphs/public"
+
+
+# only call where graph_orig has no overlap in URIs of graph_target
+def copy_vocabs_configs_from_graph(graph_orig, graph_target=DATA_GRAPH):
+    query_template = Template("""
+    PREFIX dbo: <http://dbpedia.org/ontology/>
+    PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+    PREFIX dcterms: <http://purl.org/dc/terms/>
+    PREFIX void: <http://rdfs.org/ns/void#>
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX shacl: <http://www.w3.org/ns/shacl#>
+
+    INSERT {
+      GRAPH $graph_target {
+    ?vocab a ext:VocabularyMeta;
+            rdfs:label ?label;
+            mu:uuid ?vocabUuid;
+            ext:sourceDataset ?sourceDataset;
+            ext:mappingShape ?mappingShape ;
+            dbo:alias ?alias.
+    ?sourceDataset a void:Dataset;
+            dcterms:type ?type;
+            foaf:page ?page;
+            mu:uuid ?sourceUuid;
+            void:feature ?format;
+            ext:maxRequests ?maxRequests;
+            ext:dereferenceMembers ?derefMembers.
+    ?mappingShape a shacl:NodeShape ;
+                  mu:uuid ?msUuid ;
+                  shacl:targetClass ?msTargetClass ;
+                  shacl:property ?msPropertyShape .
+    ?msPropertyShape a shacl:PropertyShape;
+                   mu:uuid ?psUuid ;
+                   shacl:path ?psPath;
+                   shacl:description ?psDescription .
+            }
+    } WHERE {
+      GRAPH $graph_source {
+        ?vocab a ext:VocabularyMeta;
+            rdfs:label ?label;
+            mu:uuid ?vocabUuid .    
+            
+        {
+            ?vocab dbo:alias ?alias .
+        } UNION {
+            ?vocab ext:sourceDataset ?sourceDataset . 
+            ?sourceDataset a void:Dataset;
+                dcterms:type ?type;
+                foaf:page ?page;
+                mu:uuid ?sourceUuid;
+                void:feature ?format;
+                ext:maxRequests ?maxRequests;
+                ext:dereferenceMembers ?derefMembers.
+        } UNION {
+            ?vocab ext:mappingShape ?mappingShape.
+            {
+                ?mappingShape a shacl:NodeShape ;
+                    mu:uuid ?msUuid ;
+                    shacl:targetClass ?msTargetClass .
+            } UNION {      
+                ?mappingShape shacl:property ?msPropertyShape .
+                ?msPropertyShape a shacl:PropertyShape;
+                    mu:uuid ?psUuid ;
+                    shacl:path ?psPath;
+                    shacl:description ?psDescription .    
+            }
+        }                       
+      }
+    } 
+    """)
+    query = query_template.substitute(
+        graph_target=sparql_escape_uri(graph_target),
+        graph_source=sparql_escape_uri(graph_orig),
+    )
+    return query
+
+
+def get_vocabs_config_triples(vocab_uris, graph=DATA_GRAPH):
+    query_template = Template("""
+PREFIX dbo: <http://dbpedia.org/ontology/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX void: <http://rdfs.org/ns/void#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX shacl: <http://www.w3.org/ns/shacl#>
+
+CONSTRUCT {
+ ?vocab a ext:VocabularyMeta;
+         mu:uuid ?vocabUuid;
+         rdfs:label ?label;
+         ext:sourceDataset ?sourceDataset;
+         ext:mappingShape ?mappingShape.
+  ?mappingShape a shacl:NodeShape ;
+                  mu:uuid ?msUuid;
+                  shacl:targetClass ?msTargetClass ;
+                  shacl:property ?msPropertyShape .
+  ?msPropertyShape a shacl:PropertyShape;
+                   mu:uuid ?psUuid;
+                   shacl:path ?psPath;
+                   shacl:description ?psDescription .        
+  ?vocab dbo:alias ?alias.
+ ?sourceDataset a void:Dataset;
+         mu:uuid ?sdUuid;
+         dcterms:type ?type;
+         foaf:page ?page;
+         void:feature ?format;
+         ext:maxRequests ?maxRequests;
+         ext:dereferenceMembers ?derefMembers.
+} WHERE {
+  GRAPH $graph {
+    VALUES ?vocab { $vocab_uris }
+   ?vocab a ext:VocabularyMeta;
+            mu:uuid ?vocabUuid;
+            rdfs:label ?label .        
+        {
+            ?vocab dbo:alias ?alias .
+        } UNION {
+            ?vocab ext:sourceDataset ?sourceDataset .
+            ?sourceDataset a void:Dataset;
+                mu:uuid ?sdUuid;
+                dcterms:type ?type;
+                foaf:page ?page;
+                void:feature ?format;
+                ext:maxRequests ?maxRequests;
+                ext:dereferenceMembers ?derefMembers.
+        } UNION {
+            ?vocab ext:mappingShape ?mappingShape.
+            {
+                ?mappingShape a shacl:NodeShape ;
+                    mu:uuid ?msUuid;
+                    shacl:targetClass ?msTargetClass .
+            } UNION {      
+                ?mappingShape shacl:property ?msPropertyShape .
+                ?msPropertyShape a shacl:PropertyShape;
+                    mu:uuid ?psUuid;
+                    shacl:path ?psPath;
+                    shacl:description ?psDescription .    
+            }
+        }                       
+  }
+} 
+                        """)
+    the_query_string = query_template.substitute(
+        graph=sparql_escape_uri(graph) if graph else "?g",
+        vocab_uris=" ".join([sparql_escape_uri(uri) for uri in vocab_uris]),
+    )
+    return the_query_string
+
+def vocab_uris_from_graph(graph):
+    query_template = Template("""
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+SELECT DISTINCT ?uri
+WHERE {
+    GRAPH $graph {
+        ?uri a ext:VocabularyMeta .
+    }
+}
+""")
+    query = query_template.substitute(
+        graph=sparql_escape_uri(graph),
+    )
+    return query
+
+def matching_aliasses_in_graph(graph_matching, graph_orig=DATA_GRAPH):
+    query_template = Template("""
+PREFIX dbo: <http://dbpedia.org/ontology/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+SELECT DISTINCT (?vocab_matching as ?vocab) ?alias
+WHERE {
+    GRAPH $graph_matching {
+        ?vocab_matching a ext:VocabularyMeta;
+                    dbo:alias ?alias .
+    }
+    FILTER EXISTS {
+        GRAPH $graph_orig {
+            ?vocab_orig a ext:VocabularyMeta;
+                    dbo:alias ?alias .
+        }
+    }
+}
+""")
+    query = query_template.substitute(
+        graph_matching=sparql_escape_uri(graph_matching),
+        graph_orig=sparql_escape_uri(graph_orig),
+    )
+    return query
+
+def matching_uris_in_graph(graph_matching, graph_orig=DATA_GRAPH):
+    query_template = Template("""
+PREFIX  ext:  <http://mu.semte.ch/vocabularies/ext/>
+SELECT DISTINCT  ?uri ?type
+WHERE { 
+  GRAPH $graph_matching { 
+    ?uri  a  ?type }
+      FILTER EXISTS { GRAPH $graph_orig
+            { ?uri a ?type }
+        }
+}
+""")
+    query = query_template.substitute(
+        graph_matching=sparql_escape_uri(graph_matching),
+        graph_orig=sparql_escape_uri(graph_orig),
+    )
+    return query
+
+def matching_vocab_uris_in_graph(graph_matching, graph_orig=DATA_GRAPH):
+    query_template = Template("""
+PREFIX  ext:  <http://mu.semte.ch/vocabularies/ext/>
+SELECT DISTINCT  ?uri
+WHERE { 
+  GRAPH $graph_matching { 
+    ?uri  a  ext:VocabularyMeta }
+      FILTER EXISTS { GRAPH $graph_orig
+            { ?uri a ext:VocabularyMeta }
+        }
+}
+""")
+    query = query_template.substitute(
+        graph_matching=sparql_escape_uri(graph_matching),
+        graph_orig=sparql_escape_uri(graph_orig),
+    )
+    return query
+
+
+def matching_dataset_uris_in_graph(graph_matching, graph_orig=DATA_GRAPH):
+    query_template = Template("""
+PREFIX  ext:  <http://mu.semte.ch/vocabularies/ext/>
+SELECT DISTINCT ?uri
+WHERE { 
+  GRAPH $graph_matching { 
+    ?vocab a   ext:VocabularyMeta .
+    ?vocab ext:sourceDataset ?uri. }
+  FILTER EXISTS { 
+    GRAPH $graph_orig { 
+      ?vocab a   ext:VocabularyMeta .
+      ?vocab ext:sourceDataset ?uri. }
+  }
+}
+""")
+    query = query_template.substitute(
+        graph_matching=sparql_escape_uri(graph_matching),
+        graph_orig=sparql_escape_uri(graph_orig),
+    )
+    return query
+
+def datasets_of_vocab(vocab_uri, graph=DATA_GRAPH):
+    query_template = Template("""
+PREFIX  ext:  <http://mu.semte.ch/vocabularies/ext/>
+SELECT DISTINCT ?uri
+WHERE { 
+  GRAPH $graph { 
+    $vocab_uri a   ext:VocabularyMeta .
+    $vocab_uri ext:sourceDataset ?uri. 
+  }
+}
+""")
+    query = query_template.substitute(
+        graph=sparql_escape_uri(graph),
+        vocab_uri=sparql_escape_uri(vocab_uri)
+    )
+    return query
+
+def remove_aliases_vocabs(vocab_aliases, graph):
+    query_template = Template("""
+        PREFIX dbo: <http://dbpedia.org/ontology/>
+        DELETE {
+          GRAPH $graph {
+            ?vocab dbo:alias ?alias .
+          }  
+        } WHERE {
+          GRAPH $graph {
+            VALUES (?vocab ?alias) {$vocab_and_alias_list}
+            ?vocab dbo:alias ?alias .
+          }
+        }
+        """)
+    delete_query = query_template.substitute(
+        graph=sparql_escape_uri(graph),
+        vocab_and_alias_list=" ".join(
+            ["(" + sparql_escape_uri(vocab) + " " + sparql_escape_string(alias) + ")" for (vocab, alias) in vocab_aliases]
+        ),
+    )
+    return delete_query
+
+
+def replace_with_uniq_uuid(uri, new_uri, new_uuid, graph):
+    query_template = Template("""
+        PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+        DELETE {
+          GRAPH $graph {
+            ?uri ?p ?s .
+            ?o ?p2 ?uri .
+            ?uri mu:uuid ?uuid .
+          }
+        }
+        INSERT {
+          GRAPH $graph {
+            ?newUri ?p ?s .
+            ?o ?p2 ?newUri .
+            ?newUri mu:uuid ?newUuid .
+          }
+        }
+        WHERE {
+          GRAPH $graph {
+            VALUES (?uri ?newUri ?newUuid) {($uri $new_uri $new_uuid)}
+            { ?uri ?p ?s . 
+              FILTER NOT EXISTS { ?uri mu:uuid ?s . }
+            }
+            UNION
+            {?o ?p2 ?uri .}
+            UNION 
+            { ?uri mu:uuid ?uuid .}
+          }
+        }
+        """)
+    # in the above query `FILTER NOT EXISTS { ?uri mu:uuid ?s . }` is done so the uuid
+    # is not part of the `?uri ?p ?s` solution (which are all added, as the uuid has to be overwritten.
+    
+    replace_query = query_template.substitute(
+        graph=sparql_escape_uri(graph),
+        uri=sparql_escape_uri(uri),
+        new_uri=sparql_escape_uri(new_uri),
+        new_uuid=sparql_escape_string(new_uuid),
+    )
+    return replace_query

--- a/services/vocab-configs/vocabularies.py
+++ b/services/vocab-configs/vocabularies.py
@@ -260,11 +260,13 @@ WHERE {
 def datasets_of_vocab(vocab_uri, graph=DATA_GRAPH):
     query_template = Template("""
 PREFIX  ext:  <http://mu.semte.ch/vocabularies/ext/>
-SELECT DISTINCT ?uri
+PREFIX dcterms: <http://purl.org/dc/terms/>
+SELECT DISTINCT ?uri ?data_type
 WHERE { 
   GRAPH $graph { 
     $vocab_uri a   ext:VocabularyMeta .
     $vocab_uri ext:sourceDataset ?uri. 
+    ?uri dcterms:type ?data_type .
   }
 }
 """)

--- a/services/vocab-configs/web.py
+++ b/services/vocab-configs/web.py
@@ -1,0 +1,207 @@
+import os
+from datetime import datetime
+from string import Template
+
+import requests
+from escape_helpers import sparql_escape, sparql_escape_uri
+from flask import request
+from helpers import generate_uuid, logger
+from helpers import query, update
+from sudo_query import query_sudo, update_sudo
+
+from vocabularies import (
+    get_vocabs_config_triples,
+    matching_aliasses_in_graph,
+    remove_aliases_vocabs,
+    copy_vocabs_configs_from_graph,
+    replace_with_uniq_uuid,
+    matching_uris_in_graph,
+    datasets_of_vocab,
+    vocab_uris_from_graph,
+)
+
+from rdflib import Graph, URIRef, Literal
+from rdflib.void import generateVoID
+
+from file import file_to_shared_uri, shared_uri_to_path
+from file import construct_get_file_query, construct_insert_file_query
+from task import run_task, find_actionable_task, start_download_task
+from sparql_util import serialize_graph_to_sparql
+
+from sparql_util import sparql_construct_res_to_graph, drop_graph, binding_results
+
+# Maybe make these configurable
+TASKS_GRAPH = "http://mu.semte.ch/graphs/public"
+FILES_GRAPH = "http://mu.semte.ch/graphs/public"
+BASE_IMPORT_GRAPH = "http://example-resource.com/graph/VocabImport/"
+
+FILE_RESOURCE_BASE = "http://example-resource.com/files/"
+MU_APPLICATION_GRAPH = os.environ.get("MU_APPLICATION_GRAPH")
+
+VOCAB_EXPORT_OPERATION = "http://mu.semte.ch/vocabularies/ext/VocabsExportJob"
+VOCAB_IMPORT_OPERATION = "http://mu.semte.ch/vocabularies/ext/VocabsImportJob"
+
+VOCABULARY_TYPE = "http://mu.semte.ch/vocabularies/ext/VocabularyMeta"
+
+
+def get_task_uri(task_uuid: str, graph: str = MU_APPLICATION_GRAPH):
+    query_template = Template("""
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+SELECT DISTINCT ?task_uri WHERE {
+    GRAPH $graph {
+        ?task_uri task:operation <http://mu.semte.ch/vocabularies/ext/dataset-download-task>;
+             mu:uuid $task_uuid .
+    }
+}
+""")
+
+    query_string = query_template.substitute(
+        graph=sparql_escape_uri(graph),
+        task_uuid=sparql_escape(task_uuid),
+    )
+    query_res = query(query_string)
+    return query_res["results"]["bindings"][0]["task_uri"]["value"]
+
+
+def do_vocab_export(vocab_uris):
+    construct_json = query_sudo(get_vocabs_config_triples(vocab_uris))
+    g = sparql_construct_res_to_graph(construct_json)
+    phys_uuid = generate_uuid()
+    phys_filename = "export_" + phys_uuid + ".ttl"
+    share_uri = file_to_shared_uri(phys_filename)
+    share_path = shared_uri_to_path(share_uri)
+    # ensure the share folder exists
+    os.makedirs(os.path.split(share_path)[0], exist_ok=True)
+    g.serialize(destination=share_path, format="turtle")
+
+    upload_resource_uuid = generate_uuid()
+    upload_resource_uri = f"{FILE_RESOURCE_BASE}{upload_resource_uuid}"
+    file_resource_uuid = generate_uuid()
+    file_resource_name = f"{file_resource_uuid}.ttl"
+
+    file = {
+        "uri": upload_resource_uri,
+        "uuid": upload_resource_uuid,
+        "name": file_resource_name,
+        "mimetype": "text/plain",
+        "created": datetime.now(),
+        "size": os.path.getsize(share_path),
+        "extension": "ttl",
+    }
+    physical_file = {
+        "uri": share_uri,
+        "uuid": phys_uuid,
+        "name": phys_filename,
+    }
+
+    query_string = construct_insert_file_query(file, physical_file, FILES_GRAPH)
+    update_sudo(query_string)
+
+    return [upload_resource_uri]
+
+
+def vocab_config_file_to_graph(file_uri: str, files_graph: str):
+    query_string = construct_get_file_query(file_uri, files_graph)
+    file_result = query_sudo(query_string)["results"]["bindings"][0]
+
+    g = Graph()
+    g.parse(shared_uri_to_path(file_result["physicalFile"]["value"]))
+
+    return g
+
+
+def import_vocab_configs(file_uri):
+    graph_uri = BASE_IMPORT_GRAPH + generate_uuid()
+
+    configs_g = vocab_config_file_to_graph(file_uri, FILES_GRAPH)
+    for query_string in serialize_graph_to_sparql(configs_g, graph_uri):
+        update_sudo(query_string)
+
+    # check if alias is already in use
+    matching_aliases_results = query_sudo(matching_aliasses_in_graph(graph_uri))
+    matching_aliases = binding_results(matching_aliases_results, ("vocab", "alias"))
+    # remove those from the import graph
+    if matching_aliases:
+        update_sudo(remove_aliases_vocabs(matching_aliases, graph_uri))
+
+    # remove overlap for UUID of vocab and sourceDatasets UUIDs and mapping UUIDs
+    matching_uris_results = query_sudo(matching_uris_in_graph(graph_uri))
+
+    for uri in binding_results(matching_uris_results, "uri"):
+        base = uri.rsplit("/", 1)[0] + "/"
+        new_uuid = generate_uuid()
+        new_uri = base + new_uuid
+        update_sudo(replace_with_uniq_uuid(uri, new_uri, new_uuid, graph_uri))
+
+    # import the desired triples from the temp_graph
+    update_sudo(copy_vocabs_configs_from_graph(graph_uri))
+
+    # get the vocab URIs that were imported
+    new_vocab_uris_results = query_sudo(vocab_uris_from_graph(graph_uri))
+    new_vocab_uris = binding_results(new_vocab_uris_results, "uri")
+    # remove import graph
+    drop_graph(graph_uri)
+    # start a download task for the new vocabs
+    for vocab_uri in new_vocab_uris:
+        datasets_results = query_sudo(datasets_of_vocab(vocab_uri))
+        for dataset_uri in binding_results(datasets_results, "uri"):
+            # not all datasets are part of a vocabulary. A dataset has multiple `void:propertyPartition` Datasets
+            update_sudo(start_download_task(dataset_uri, TASKS_GRAPH))
+
+    return new_vocab_uris
+
+
+@app.route("/delta", methods=["POST"])
+def process_delta():
+    inserts = request.json[0]["inserts"]
+    try:
+        task_triple = next(
+            filter(
+                lambda x: x["predicate"]["value"] == "http://www.w3.org/ns/adms#status"
+                and x["object"]["value"]
+                == "http://redpencil.data.gift/id/concept/JobStatus/scheduled",
+                inserts,
+            )
+        )
+    except StopIteration:
+        return "Can't do anything with this delta. Skipping.", 500
+    task_uri = task_triple["subject"]["value"]
+
+    task_q = find_actionable_task(task_uri, TASKS_GRAPH)
+    task_res = query_sudo(task_q)
+    if task_res["results"]["bindings"]:
+        task_operation = [
+            binding["operation"]["value"]
+            for binding in task_res["results"]["bindings"]
+            if "operation" in binding
+        ][0]
+    else:
+        return "Don't know how to handle task without operation type", 500
+
+    if task_operation == VOCAB_EXPORT_OPERATION:
+        logger.debug(f"Running task {task_uri}, operation {task_operation}")
+        run_task(
+            task_uri,
+            TASKS_GRAPH,
+            lambda sources: do_vocab_export(sources),
+            query_sudo,
+            update_sudo,
+        )
+        return "", 200
+    elif task_operation == VOCAB_IMPORT_OPERATION:
+        logger.debug(f"Running task {task_uri}, operation {task_operation}")
+        run_task(
+            task_uri,
+            TASKS_GRAPH,
+            lambda fileUris: import_vocab_configs(fileUris[0]),
+            query_sudo,
+            update_sudo,
+        )
+        return "", 200
+    else:
+        return (
+            "Don't know how to handle task with operation type " + task_operation,
+            500,
+        )

--- a/services/vocab-fetch/dataset.py
+++ b/services/vocab-fetch/dataset.py
@@ -12,13 +12,14 @@ PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 PREFIX dc: <http://purl.org/dc/terms/>
 
-SELECT DISTINCT (?page AS ?download_link) ?format ?download_url ?data_dump ?type ?dataset_graph
+SELECT DISTINCT (?page AS ?download_link) ?format ?download_url ?data_dump ?type ?dataset_graph ?vocab
 WHERE {
     GRAPH $graph {
         $dataset
             a void:Dataset ;
             foaf:page ?download_url ;
             dc:type ?type .
+        ?vocab ext:sourceDataset $dataset.    
         OPTIONAL { $dataset void:feature ?format . }
         OPTIONAL { $dataset void:dataDump ?data_dump . }
         OPTIONAL { $dataset ext:datasetGraph ?dataset_graph . }

--- a/services/vocab-fetch/dataset.py
+++ b/services/vocab-fetch/dataset.py
@@ -7,19 +7,18 @@ MU_APPLICATION_GRAPH = os.environ.get("MU_APPLICATION_GRAPH")
 def get_dataset(dataset, graph=MU_APPLICATION_GRAPH):
     query_template = Template("""
 PREFIX void: <http://rdfs.org/ns/void#>
-PREFIX cogs: <http://vocab.deri.ie/cogs#>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 PREFIX dc: <http://purl.org/dc/terms/>
 
-SELECT DISTINCT (?page AS ?download_link) ?format ?download_url ?data_dump ?type ?dataset_graph ?vocab
+SELECT DISTINCT ?format ?download_url ?data_dump ?type ?dataset_graph ?vocab
 WHERE {
     GRAPH $graph {
         $dataset
             a void:Dataset ;
             foaf:page ?download_url ;
             dc:type ?type .
-        ?vocab ext:sourceDataset $dataset.    
+        ?vocab ext:sourceDataset $dataset.
         OPTIONAL { $dataset void:feature ?format . }
         OPTIONAL { $dataset void:dataDump ?data_dump . }
         OPTIONAL { $dataset ext:datasetGraph ?dataset_graph . }

--- a/services/vocab-fetch/sparql_util.py
+++ b/services/vocab-fetch/sparql_util.py
@@ -1,11 +1,23 @@
+import os
 from escape_helpers import sparql_escape_uri
+from string import Template
+from datetime import datetime
+from file import file_to_shared_uri, shared_uri_to_path
+from file import construct_get_file_query, construct_insert_file_query
 from more_itertools import batched
-
+from format_to_mime import FORMAT_TO_MIME_EXT
+from helpers import generate_uuid, logger
+from helpers import query, update
+from sudo_query import query_sudo, update_sudo
+import requests
 BATCH_SIZE = 100
 
+FILE_RESOURCE_BASE = "http://example-resource.com/"
+MU_VIRTUOSO_ENDPOINT = os.environ.get("MU_VIRTUOSO_ENDPOINT")
 
 # adapted from https://github.com/RDFLib/rdflib/issues/1704
 def serialize_graph_to_sparql(g, graph_name: str):
+    """RDFlib graph to sparql"""
     for triples_batch in batched(g.triples((None, None, None)), BATCH_SIZE):
         updatequery = "\n".join(
             [f"PREFIX {prefix}: {ns.n3()}" for prefix, ns in g.namespaces()]
@@ -17,6 +29,80 @@ def serialize_graph_to_sparql(g, graph_name: str):
         updatequery += f" . \n\t }}\n}}\n"
         yield updatequery
 
+dump_graph_query_template = Template("""
+CONSTRUCT {
+    ?s ?p ?o .
+}
+WHERE
+{
+    {
+        SELECT DISTINCT ?s ?p ?o
+        FROM $graph
+        WHERE
+        {
+            ?s ?p ?o .
+        }
+        ORDER BY ASC(?s)
+    }
+}
+OFFSET $offset
+LIMIT $limit
+""")
+
+def graph_to_file(graph_name, graph):
+    """triplestore graph to file"""
+    mime_type = "text/plain"
+    file_extension = "nt"
+    upload_resource_uuid = generate_uuid()
+    upload_resource_uri = f"{FILE_RESOURCE_BASE}{upload_resource_uuid}"
+    file_resource_uuid = generate_uuid()
+    file_resource_name = f"{file_resource_uuid}.{file_extension}"
+
+    file_resource_uri = file_to_shared_uri(file_resource_name)
+
+    headers = {"Accept": mime_type}
+
+    i = 0
+    with open(shared_uri_to_path(file_resource_uri), "wb") as f:
+        while True:
+            query_string = dump_graph_query_template.substitute(
+                graph=sparql_escape_uri(graph_name),
+                offset=i*BATCH_SIZE,
+                limit=BATCH_SIZE
+            )
+            url = MU_VIRTUOSO_ENDPOINT + '?query=' + query_string
+            with requests.get(url, headers=headers, stream=True) as res:
+                assert res.ok
+                if res.content == b'# Empty NT\n':
+                    break
+                for chunk in res.iter_content(chunk_size=None):
+                    f.write(chunk)
+                i += 1
+
+        f.seek(0, 2)
+        file_size = f.tell()
+
+    file = {
+        "uri": upload_resource_uri,
+        "uuid": upload_resource_uuid,
+        "name": file_resource_name,
+        "mimetype": "text/plain",
+        "created": datetime.now(),
+        "size": file_size,
+        "extension": file_extension,
+    }
+    physical_file = {
+        "uri": file_resource_uri,
+        "uuid": file_resource_uuid,
+        "name": file_resource_name,
+    }
+
+    query_string = construct_insert_file_query(file, physical_file, graph)
+
+    # TODO Check query result before writing file to disk
+    update_sudo(query_string)
+
+    return upload_resource_uri
 
 def binding_results(json_result, binded_values):
     bindings = []

--- a/services/vocab-fetch/sparql_util.py
+++ b/services/vocab-fetch/sparql_util.py
@@ -3,11 +3,30 @@ from more_itertools import batched
 
 BATCH_SIZE = 100
 
+
 # adapted from https://github.com/RDFLib/rdflib/issues/1704
 def serialize_graph_to_sparql(g, graph_name: str):
     for triples_batch in batched(g.triples((None, None, None)), BATCH_SIZE):
-        updatequery = "\n".join([f"PREFIX {prefix}: {ns.n3()}" for prefix, ns in g.namespaces()])
+        updatequery = "\n".join(
+            [f"PREFIX {prefix}: {ns.n3()}" for prefix, ns in g.namespaces()]
+        )
         updatequery += f"\nINSERT DATA {{\n\tGRAPH {sparql_escape_uri(graph_name)} {{\n"
-        updatequery += " .\n".join([f"\t\t{s.n3()} {p.n3()} {o.n3()}" for (s, p, o) in triples_batch])
+        updatequery += " .\n".join(
+            [f"\t\t{s.n3()} {p.n3()} {o.n3()}" for (s, p, o) in triples_batch]
+        )
         updatequery += f" . \n\t }}\n}}\n"
         yield updatequery
+
+
+def binding_results(json_result, binded_values):
+    bindings = []
+    for binding in json_result["results"]["bindings"]:
+        if isinstance(binded_values, tuple):
+            values = tuple(
+                (binding[key]["value"] if key in binding else None)
+                for key in binded_values
+            )
+        else:
+            values = binding[binded_values]["value"]
+        bindings.append(values)
+    return bindings

--- a/services/vocab-fetch/task.py
+++ b/services/vocab-fetch/task.py
@@ -111,6 +111,35 @@ LIMIT 1
     )
     return query_string
 
+
+def find_actionable_task_of_type(types, graph):
+    query_template = Template("""
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX cogs: <http://vocab.deri.ie/cogs#>
+PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+SELECT (?task as ?uri) (?uuid as ?id) ?created ?used ?operation ?job_operation WHERE {
+    GRAPH $graph {
+        ?task a task:Task ;
+            dct:created ?created ;
+            adms:status <http://redpencil.data.gift/id/concept/JobStatus/scheduled> ;
+            task:operation ?operation ;
+            mu:uuid ?uuid .
+        OPTIONAL { ?task task:inputContainer/ext:content ?used }
+        OPTIONAL {?task dct:isPartOf/task:operation ?job_operation}
+        VALUES ?operation {$task_types}
+    }
+} LIMIT 1
+""")
+    query_string = query_template.substitute(
+        graph=sparql_escape_uri(graph) if graph else "?g",
+        task_types = " ".join([sparql_escape_uri(uri) for uri in types])
+        )
+    return query_string
+
 def run_task(task_uri, graph, runner_func, sparql_query, sparql_update):
     # start_time = time.time()
 

--- a/services/vocab-fetch/web.py
+++ b/services/vocab-fetch/web.py
@@ -1,6 +1,7 @@
 import os
 from datetime import datetime
 from string import Template
+import threading
 
 import requests
 from escape_helpers import sparql_escape, sparql_escape_uri
@@ -14,9 +15,9 @@ from rdflib.void import generateVoID
 
 from file import file_to_shared_uri, shared_uri_to_path
 from file import construct_get_file_query, construct_insert_file_query
-from task import run_task, find_actionable_task
+from task import find_actionable_task_of_type, run_task, find_actionable_task
 from dataset import get_dataset, update_dataset_download, get_dataset_by_uuid
-from sparql_util import serialize_graph_to_sparql
+from sparql_util import binding_results, serialize_graph_to_sparql
 from format_to_mime import FORMAT_TO_MIME_EXT
 
 # Maybe make these configurable
@@ -24,27 +25,33 @@ TASKS_GRAPH = "http://mu.semte.ch/graphs/public"
 FILES_GRAPH = "http://mu.semte.ch/graphs/public"
 VOID_DATASET_GRAPH = "http://mu.semte.ch/graphs/public"
 
-FILE_RESOURCE_BASE = 'http://example-resource.com/'
+FILE_RESOURCE_BASE = "http://example-resource.com/"
 MU_APPLICATION_GRAPH = os.environ.get("MU_APPLICATION_GRAPH")
-VOID_DATASET_RESOURCE_BASE = 'http://example-resource.com/void-dataset/'
+VOID_DATASET_RESOURCE_BASE = "http://example-resource.com/void-dataset/"
+
+VOCAB_DOWNLOAD_JOB = "http://lblod.data.gift/id/jobs/concept/JobOperation/vocab-download"
+
 
 def load_vocab_file(uri: str, graph: str = MU_APPLICATION_GRAPH):
     query_string = construct_get_file_query(uri, graph)
-    file_result = query_sudo(query_string)['results']['bindings'][0]
+    file_result = query_sudo(query_string)["results"]["bindings"][0]
 
     g = Graph()
-    g.parse(shared_uri_to_path(file_result['physicalFile']['value']))
+    g.parse(shared_uri_to_path(file_result["physicalFile"]["value"]))
 
     return g
 
+
 def download_vocab_file(url: str, format: str, graph: str = MU_APPLICATION_GRAPH):
     mime_type, file_extension = FORMAT_TO_MIME_EXT[format]
-    accept_string = ', '.join(
-        value[0] + (';q=1.0' if key == format else ';q=0.1') for key, value in FORMAT_TO_MIME_EXT.items())
+    accept_string = ", ".join(
+        value[0] + (";q=1.0" if key == format else ";q=0.1")
+        for key, value in FORMAT_TO_MIME_EXT.items()
+    )
     upload_resource_uuid = generate_uuid()
-    upload_resource_uri = f'{FILE_RESOURCE_BASE}{upload_resource_uuid}'
+    upload_resource_uri = f"{FILE_RESOURCE_BASE}{upload_resource_uuid}"
     file_resource_uuid = generate_uuid()
-    file_resource_name = f'{file_resource_uuid}.{file_extension}'
+    file_resource_name = f"{file_resource_uuid}.{file_extension}"
 
     file_resource_uri = file_to_shared_uri(file_resource_name)
 
@@ -52,16 +59,15 @@ def download_vocab_file(url: str, format: str, graph: str = MU_APPLICATION_GRAPH
 
     with requests.get(url, headers=headers, stream=True) as res:
         if res.url != url:
-            logger.info(
-                "You've been redirected. Probably want to replace url in db.")
+            logger.info("You've been redirected. Probably want to replace url in db.")
 
         assert res.ok
 
         # TODO: better handling + negociating
         logger.info(f'Content-Type: {res.headers["Content-Type"]}')
-        logger.info(f'MIME-Type: {mime_type}')
+        logger.info(f"MIME-Type: {mime_type}")
 
-        with open(shared_uri_to_path(file_resource_uri), 'wb') as f:
+        with open(shared_uri_to_path(file_resource_uri), "wb") as f:
             for chunk in res.iter_content(chunk_size=None):
                 f.write(chunk)
 
@@ -69,18 +75,18 @@ def download_vocab_file(url: str, format: str, graph: str = MU_APPLICATION_GRAPH
             file_size = f.tell()
 
     file = {
-        'uri': upload_resource_uri,
-        'uuid': upload_resource_uuid,
-        'name': file_resource_name,
-        'mimetype': 'text/plain',
-        'created': datetime.now(),
-        'size': file_size,
-        'extension': file_extension,
+        "uri": upload_resource_uri,
+        "uuid": upload_resource_uuid,
+        "name": file_resource_name,
+        "mimetype": "text/plain",
+        "created": datetime.now(),
+        "size": file_size,
+        "extension": file_extension,
     }
     physical_file = {
-        'uri': file_resource_uri,
-        'uuid': file_resource_uuid,
-        'name': file_resource_name,
+        "uri": file_resource_uri,
+        "uuid": file_resource_uuid,
+        "name": file_resource_name,
     }
 
     query_string = construct_insert_file_query(file, physical_file, graph)
@@ -90,13 +96,15 @@ def download_vocab_file(url: str, format: str, graph: str = MU_APPLICATION_GRAPH
 
     return upload_resource_uri
 
+
 def escape(binding):
-    if binding['type'] == 'uri':
-        return URIRef(binding['value'])
-    elif binding['type'] == 'typed-literal':
-        return Literal(binding['value'], datatype=binding['datatype'])
+    if binding["type"] == "uri":
+        return URIRef(binding["value"])
+    elif binding["type"] == "typed-literal":
+        return Literal(binding["value"], datatype=binding["datatype"])
     else:
-        return Literal(binding['value'])
+        return Literal(binding["value"])
+
 
 def load_vocab_graph(graph: str):
     query_template = Template("""
@@ -106,17 +114,16 @@ SELECT ?s ?p ?o WHERE {
     }
 }
 """)
-    query_string = query_template.substitute(
-        graph=sparql_escape_uri(graph)
-    )
-    results = query_sudo(query_string)['results']['bindings']
+    query_string = query_template.substitute(graph=sparql_escape_uri(graph))
+    results = query_sudo(query_string)["results"]["bindings"]
     g = Graph()
     for triple in results:
-        g.add(tuple(map(escape, (triple['s'], triple['p'], triple['o']))))
+        g.add(tuple(map(escape, (triple["s"], triple["p"], triple["o"]))))
     return g
 
+
 def get_task_uri(task_uuid: str, graph: str = MU_APPLICATION_GRAPH):
-    query_template = Template('''
+    query_template = Template("""
 PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
 PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
@@ -126,14 +133,14 @@ SELECT DISTINCT ?task_uri WHERE {
              mu:uuid $task_uuid .
     }
 }
-''')
+""")
 
     query_string = query_template.substitute(
         graph=sparql_escape_uri(graph),
         task_uuid=sparql_escape(task_uuid),
     )
     query_res = query(query_string)
-    return query_res['results']['bindings'][0]['task_uri']['value']
+    return query_res["results"]["bindings"][0]["task_uri"]["value"]
 
 def redownload_dataset(dataset_uri):
     dataset_result = query_sudo(get_dataset(dataset_uri, VOID_DATASET_GRAPH))['results']['bindings'][0]
@@ -143,7 +150,8 @@ def redownload_dataset(dataset_uri):
     update_sudo(update_dataset_download(dataset_uri, file_uri, VOID_DATASET_GRAPH))
     return dataset_uri
 
-@app.route('/dataset-download-task/<task_uuid>/run', methods=['POST'])
+
+@app.route("/dataset-download-task/<task_uuid>/run", methods=["POST"])
 def run_dataset_download_route(task_uuid: str):
     try:
         task_uri = get_task_uri(task_uuid)
@@ -156,68 +164,126 @@ def run_dataset_download_route(task_uuid: str):
         TASKS_GRAPH,
         lambda sources: [redownload_dataset(sources[0])],
         query_sudo,
-        update_sudo
+        update_sudo,
     )
 
-    return ''
+    return ""
+
 
 def remove_old_metadata_from_graph(g, graph_name):
-    for (s,p,_) in g.triples((None, None, None)):
-        deletequery = "\n".join([f"PREFIX {prefix}: {ns.n3()}" for prefix, ns in g.namespaces()])
-        deletequery += f"\nDELETE WHERE {{\n\tGRAPH {sparql_escape_uri(graph_name)} {{\n"
+    for s, p, _ in g.triples((None, None, None)):
+        deletequery = "\n".join(
+            [f"PREFIX {prefix}: {ns.n3()}" for prefix, ns in g.namespaces()]
+        )
+        deletequery += (
+            f"\nDELETE WHERE {{\n\tGRAPH {sparql_escape_uri(graph_name)} {{\n"
+        )
         deletequery += f" \t\t{s.n3()} {p.n3()} ?o ."
         deletequery += f" \n\t }}\n}}\n"
         update_sudo(deletequery)
 
 
-def generate_dataset_structural_metadata(dataset_uri):
-    dataset_res = query_sudo(get_dataset(dataset_uri, VOID_DATASET_GRAPH))['results']['bindings'][0]
-    if 'data_dump' in dataset_res.keys():
-        dataset_contents_g = load_vocab_file(dataset_res['data_dump']['value'], FILES_GRAPH)
+def generate_dataset_structural_metadata(dataset_uri, should_return_vocab):
+    dataset_res = query_sudo(get_dataset(dataset_uri, VOID_DATASET_GRAPH))["results"][
+        "bindings"
+    ][0]
+    if "data_dump" in dataset_res.keys():
+        dataset_contents_g = load_vocab_file(
+            dataset_res["data_dump"]["value"], FILES_GRAPH
+        )
     else:
-        dataset_contents_g = load_vocab_graph(dataset_res['dataset_graph']['value'])
-    dataset_meta_g, dataset = generateVoID(dataset_contents_g, dataset=URIRef(dataset_uri))
+        dataset_contents_g = load_vocab_graph(dataset_res["dataset_graph"]["value"])
+    dataset_meta_g, dataset = generateVoID(
+        dataset_contents_g, dataset=URIRef(dataset_uri)
+    )
     remove_old_metadata_from_graph(dataset_meta_g, VOID_DATASET_GRAPH)
     for query_string in serialize_graph_to_sparql(dataset_meta_g, VOID_DATASET_GRAPH):
         update_sudo(query_string)
-    return dataset_uri
+    if should_return_vocab:
+      return dataset_res["vocab"]["value"]
+    else:
+      return dataset_uri    
+
 
 VOCAB_DOWNLOAD_OPERATION = "http://mu.semte.ch/vocabularies/ext/VocabDownloadJob"
-METADATA_EXTRACTION_OPERATION = "http://mu.semte.ch/vocabularies/ext/MetadataExtractionJob"
+METADATA_EXTRACTION_OPERATION = (
+    "http://mu.semte.ch/vocabularies/ext/MetadataExtractionJob"
+)
 
-@app.route('/delta', methods=['POST'])
+running_tasks_lock = threading.Lock()
+
+
+def run_tasks():
+    # run this function only once at a time to avoid overloading the service
+    acquired = running_tasks_lock.acquire(blocking=False)
+
+    if not acquired:
+        logger.debug("Already running `run_tasks`")
+        return
+
+    try:
+        while True:
+            task_q = find_actionable_task_of_type(
+                [VOCAB_DOWNLOAD_OPERATION, METADATA_EXTRACTION_OPERATION], TASKS_GRAPH
+            )
+            task_res = query_sudo(task_q)
+            if task_res["results"]["bindings"]:
+                (task_uri, task_operation, job_operation) = binding_results(
+                    task_res, ("uri", "operation", "job_operation")
+                )[0]
+            else:
+                logger.debug("No more tasks found")
+                return
+            try:
+                if task_operation == VOCAB_DOWNLOAD_OPERATION:
+                    logger.debug(f"Running task {task_uri}, operation {task_operation}")
+                    run_task(
+                        task_uri,
+                        TASKS_GRAPH,
+                        lambda sources: [redownload_dataset(sources[0])],
+                        query_sudo,
+                        update_sudo,
+                    )
+
+                elif task_operation == METADATA_EXTRACTION_OPERATION:
+                    logger.debug(f"Running task {task_uri}, operation {task_operation}")
+                    # this task is part of a job that will run unification afterwards
+                    # which needs vocab uri as the output of previous job
+                    # Maybe better to create an extra task "metadata_extraction_before_unification"
+                    # which can be used in the VOCAB_DOWNLOAD job
+                    should_return_vocab = (job_operation == VOCAB_DOWNLOAD_JOB)
+                    run_task(
+                        task_uri,
+                        TASKS_GRAPH,
+                        lambda sources: [
+                            generate_dataset_structural_metadata(sources[0], should_return_vocab)
+                        ],
+                        query_sudo,
+                        update_sudo,
+                    )
+
+            finally:
+                logger.warn(
+                    f"Problem while running task {task_uri}, operation {task_operation}"
+                )
+    finally:
+        running_tasks_lock.release()
+
+
+@app.route("/delta", methods=["POST"])
 def process_delta():
-    inserts = request.json[0]['inserts']
-    task_triples = [t for t in inserts if t['predicate']['value'] == 'http://www.w3.org/ns/adms#status' and t['object']['value'] == 'http://redpencil.data.gift/id/concept/JobStatus/scheduled']
+    inserts = request.json[0]["inserts"]
+    task_triples = [
+        t
+        for t in inserts
+        if t["predicate"]["value"] == "http://www.w3.org/ns/adms#status"
+        and t["object"]["value"]
+        == "http://redpencil.data.gift/id/concept/JobStatus/scheduled"
+    ]
     if not task_triples:
         return "Can't do anything with this delta. Skipping.", 500
-    for task_triple in task_triples:  
-        task_uri = task_triple['subject']['value']
 
-        task_q = find_actionable_task(task_uri, TASKS_GRAPH)
-        task_res = query_sudo(task_q)
-        if task_res["results"]["bindings"]:
-            task_operation = [binding["operation"]['value'] for binding in task_res["results"]["bindings"] if "operation" in binding][0]
-            if task_operation == VOCAB_DOWNLOAD_OPERATION:
-                logger.debug(f"Running task {task_uri}, operation {task_operation}")
-                run_task(
-                    task_uri,
-                    TASKS_GRAPH,
-                    lambda sources: [redownload_dataset(sources[0])],
-                    query_sudo,
-                    update_sudo
-                )
-                return '', 200
-            elif task_operation == METADATA_EXTRACTION_OPERATION:
-                logger.debug(f"Running task {task_uri}, operation {task_operation}")
-                run_task(
-                    task_uri,
-                    TASKS_GRAPH,
-                    lambda sources: [generate_dataset_structural_metadata(sources[0])],
-                    query_sudo,
-                    update_sudo
-                )
-                return '', 200
-            else:
-                logger.debug(f"Task {task_uri}, has unknown operation type {task_operation}")
-    return "Don't know how to do these tasks", 500  
+    thread = threading.Thread(target=run_tasks)
+    thread.start()
+
+    return "", 200


### PR DESCRIPTION
see frontend https://github.com/redpencilio/frontend-vocabserver/pull/25

+ add two types of tasks to:
	- authorization
	- delta-notifier: to notify vocab-configs when these tasks get created
	- job-controller: to keep the same logic of other tasks, even though it is only one task that has to happen.

+ Add the file service to upload and download files

+ changes to vocab-fetch service to look at *all* potential task urls

+ create the vocab-configs service
	- runs on delta changes with specific import/export task
	- General logic copied from other services. Task creation logic changed a bit to support string-set content for taskContainer (used to return multiple uris when importing a vocab-config)
	- will create vocab-fetch task for all datasets after importing vocabs