### PR TITLE
Add endpoint to serve webcomponent module file

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,11 +149,19 @@ Repository: https://github.com/kanselarij-vlaanderen/uuid-generation-service
 
 Data used within a semantic.works-stack (and mu-cl-resources in particular) requires each RDF-object to have a mu:uuid property. Data imported from third parties might not have this uuid. Thus, in order to integrate with other sources while harnessing the power of semantic.works, uuid's need to be added to each imported object. This service does exactly that.
 
+### vocab-configs
+Responsible for exporting and importing one or more vocabularies, to duplicate or transfer vocabularies between application. See `services/vocab-configs`. 
+
 ### vocab-fetch
 Responsible for downloading and analyzing vocabularies. Part of this repository, can be found under `services/vocab-fetch`.
 
 ### content-unification
 Transforms a downloaded vocabulary to a harmonized model so it can be index by mu-search. Part of this repository, can be found under `services/content-unification`.
+
+### webcomponent
+Serves the build webcomponent module file, so it can be references in a script tag. The dispatcher is configured to serve this file under `/webcomponent/main.js`.   
+TODO: this image is not yet published
+
 
 ### ldes-consumer-manager
 Repository: https://github.com/redpencilio/ldes-consumer-manager/

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -20,6 +20,10 @@ defmodule Dispatcher do
   # Run `docker-compose restart dispatcher` after updating
   # this file.
 
+  get "/webcomponent/main.js", @any do
+    forward conn, [], "http://webcomponent/vocab-search-bar.js"
+  end
+
   post "/vocab-download-jobs/:id/run", @json do
     forward conn, [], "http://vocab-fetch/" <> id
   end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,8 +137,8 @@ services:
       - ./config/uuid-generation/:/config
     restart: always
     logging: *default-logging
-  # webcomponent:
-  #   image: vocabsearch-webcomponent
+  webcomponent:
+    image: vocabsearch-webcomponent
   ldes-consumer-manager:
     image: redpencil/ldes-consumer-manager:0.1.0
     environment:


### PR DESCRIPTION
needs commit https://github.com/vlizBE/vocabserver-webcomponent/pull/8/commits/d2b6659984cb706a51e2313ea9ae330e561dff98 for the correct docker image

*TODO*: The image of the webcomponent is not a published image (but a local reference). Hence, this will not work without either building the webcomponent image locally, or publishing an image and changing the image reference in the docker-compose file.